### PR TITLE
Modernizing recipe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,6 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
-
 find_package(Git)
 if (GIT_FOUND)
   execute_process(

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
 
 # Clang
-conan install . -g cmake -if build -b outdated \
-    -s compiler.version=12 -s compiler=clang \
-    -s compiler.libcxx=libstdc++11 -s compiler.runtime=MTd \
-    -e CC=clang -e CXX=clang++ \
-    -e CONAN_CMAKE_GENERATOR=Ninja
-
+conan install . -if build -b outdated -pr clang_profile -pr:b clang_profile
 conan build . --build-folder build

--- a/clang_profile
+++ b/clang_profile
@@ -1,0 +1,11 @@
+include(default)
+
+[settings]
+build_type=Release
+compiler=clang
+compiler.runtime=MTd
+compiler.version=12
+[env]
+CC=clang
+CONAN_CMAKE_GENERATOR=Ninja
+CXX=clang++

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from conans import ConanFile, CMake
+from conans import ConanFile
+from conan.tools.cmake import CMake
 
 
 class UtilsConan(ConanFile):
@@ -23,7 +24,7 @@ class UtilsConan(ConanFile):
         "fPIC": True,
     }
 
-    generators = "cmake", "cmake_find_package"
+    generators = "CMakeDeps", "CMakeToolchain"
     build_policy = "missing"
 
     def config_options(self):


### PR DESCRIPTION
Solved bug for legacy `"cmake"` and `"cmake_find_package"` generators:

* Using new generators for more modern recipes.
* Using profile for both types of machines: host and build.
* Removing some useless lines from CMakeLists.txt

Issue related: https://github.com/conan-io/conan/issues/9537