### PR TITLE
Resolved runtime MT problem

### DIFF
--- a/.profile/clang_x86_64_asan
+++ b/.profile/clang_x86_64_asan
@@ -12,5 +12,5 @@ compiler.runtime=MT
 [env]
 CC="C:/Program Files/LLVM/bin/clang"
 CXX="C:/Program Files/LLVM/bin/clang++"
-CFLAGS=-fsanitize=address
-CXXFLAGS=-fsanitize=address
+CFLAGS=-MT -fsanitize=address
+CXXFLAGS=-MT -fsanitize=address


### PR DESCRIPTION
Issue related: https://github.com/conan-io/conan/issues/9537#issuecomment-952025285

Added manually `-MT` runtime to CC/CXX flags.